### PR TITLE
last_reply_at is non-null

### DIFF
--- a/src/Controllers/ChatterDiscussionController.php
+++ b/src/Controllers/ChatterDiscussionController.php
@@ -111,6 +111,7 @@ class ChatterDiscussionController extends Controller
             'user_id'             => $user_id,
             'slug'                => $slug,
             'color'               => $request->color,
+            'last_reply_at'       => Carbon::now(),
             ];
 
         $category = Models::category()->find($request->chatter_category_id);


### PR DESCRIPTION
For the DB migration, the `last_reply_at` field is set to non nullable so this sets that field upon post creation